### PR TITLE
feat: Model User_Micropost one_to_many

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,3 @@
 class Micropost < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :microposts, dependent: :destroy
+
   validates :name, presence: true
   validates :email, presence: true
   validates :email, uniqueness: true


### PR DESCRIPTION
close #13 

## 概要
・UserとMicropostを１対多の関係にするため、各Modelにhas_manyとbelongs_toを付与
・User側には、 dependent: :destroyでUserを削除すると関連するMicropostも削除する様に設定

## 修正内容の検証方法
・ローカルにて、rails consoleで関連していることを確認
・Web上でも確認
・rubocopで確認

## この修正が正しい理由
・ローカルの確認は Micropost.userで関係したユーザーを確認
・Web上で削除してみたら関連した物が削除されたことを確認
・rubocop確認
